### PR TITLE
attempt converted camelCase strings to SNAKE_CASE constants

### DIFF
--- a/!!!PlaySoundFixer.toc
+++ b/!!!PlaySoundFixer.toc
@@ -1,6 +1,5 @@
 ## Interface: 70300
 ## Title: PlaySoundFixer
 ## Notes: Traces the source of broken PlaySound calls so you can fix them
-## Author: Alex Folland
+## Author: Alex Folland, Erorus
 PlaySoundFixer.lua
-## SavedVariables: PlaySoundFixerDB

--- a/PlaySoundFixer.lua
+++ b/PlaySoundFixer.lua
@@ -2,9 +2,22 @@ local oldPlaySound = PlaySound
 PlaySound = function(sound, ...)
     if type(sound)=="number" then
         return oldPlaySound(sound, ...)
-    else
-        local soundstring = tostring(sound)
-        local source = gsub(strtrim(debugstack(2,1,0),".\n"),"Interface\\AddOns\\","")
-        print("PSF: broken PlaySound(\""..soundstring.."\") called from "..source)
     end
+
+    local soundstring = tostring(sound)
+    local converted = ''
+    for i = 1, #soundstring do
+        local c = soundstring:sub(i,i)
+        if converted ~= '' and c == c:upper() then
+            converted = converted .. "_"
+        end
+        converted = converted .. c:upper()
+    end
+
+    if SOUNDKIT[converted] then
+        return oldPlaySound(SOUNDKIT[converted], ...)
+    end
+
+    local source = gsub(strtrim(debugstack(2,1,0),".\n"),"Interface\\AddOns\\","")
+    print("PSF: broken PlaySound(\""..soundstring.."\") called from "..source)
 end


### PR DESCRIPTION
Calls to e.g. `PlaySound("UChatScrollButton")` will look for `SOUNDKIT.U_CHAT_SCROLL_BUTTON` and use the constant when available.

Hope you don't mind my adding my name to the toc, figured I added about as much code, so.. ;)